### PR TITLE
Allow for --set-gtid-purged=xxx

### DIFF
--- a/files/drush-extra-dump.patch
+++ b/files/drush-extra-dump.patch
@@ -1,0 +1,69 @@
+From 1b89261a7f830f923d36f864057656ebb92083a2 Mon Sep 17 00:00:00 2001
+From: Paul Maddern <pobster@25159.no-reply.drupal.org>
+Date: Thu, 19 Sep 2019 15:39:18 +0100
+Subject: [PATCH] fix(dump): Allows GTID-purged to be set as a Drush option.
+
+---
+ commands/sql/sql.drush.inc  | 1 +
+ lib/Drush/Sql/Sqlmysql.php  | 3 +++
+ lib/Drush/Sql/Sqlpgsql.php  | 3 +++
+ lib/Drush/Sql/Sqlsqlite.php | 3 +++
+ 4 files changed, 10 insertions(+)
+
+diff --git a/commands/sql/sql.drush.inc b/commands/sql/sql.drush.inc
+index 1aa09452..f84c1f62 100644
+--- a/commands/sql/sql.drush.inc
++++ b/commands/sql/sql.drush.inc
+@@ -120,6 +120,7 @@ function sql_drush_command() {
+       'ordered-dump' => 'Order by primary key and add line breaks for efficient diff in revision control. Slows down the dump. Mysql only.',
+       'gzip' => 'Compress the dump using the gzip program which must be in your $PATH.',
+       'extra' => 'Add custom options to the dump command.',
++      'extra-dump' => 'Add custom arguments/options to the dumping of the database (e.g. mysqldump command).',
+     ) + $options + $db_url,
+     'aliases' => array('sql:dump'),
+   );
+diff --git a/lib/Drush/Sql/Sqlmysql.php b/lib/Drush/Sql/Sqlmysql.php
+index 9318d164..c8efeabf 100644
+--- a/lib/Drush/Sql/Sqlmysql.php
++++ b/lib/Drush/Sql/Sqlmysql.php
+@@ -149,6 +149,9 @@ EOT;
+     if ($option = drush_get_option('extra', $this->query_extra)) {
+       $extra .= " $option";
+     }
++    if ($option = drush_get_option('extra-dump')) {
++      $extra .= " $option";
++    }
+     $exec .= $extra;
+ 
+     if (!empty($tables)) {
+diff --git a/lib/Drush/Sql/Sqlpgsql.php b/lib/Drush/Sql/Sqlpgsql.php
+index e0fc46ce..f50e692d 100644
+--- a/lib/Drush/Sql/Sqlpgsql.php
++++ b/lib/Drush/Sql/Sqlpgsql.php
+@@ -124,6 +124,9 @@ class Sqlpgsql extends SqlBase {
+     if ($option = drush_get_option('extra')) {
+       $extra .= " $option";
+     }
++    if ($option = drush_get_option('extra-dump')) {
++      $extra .= " $option";
++    }
+     $exec .= $extra;
+     $exec .= (!isset($create_db) && !isset($data_only) ? ' --clean' : '');
+ 
+diff --git a/lib/Drush/Sql/Sqlsqlite.php b/lib/Drush/Sql/Sqlsqlite.php
+index 2182afb3..6eea8b1d 100644
+--- a/lib/Drush/Sql/Sqlsqlite.php
++++ b/lib/Drush/Sql/Sqlsqlite.php
+@@ -94,6 +94,9 @@ class Sqlsqlite extends SqlBase {
+     if ($option = drush_get_option('extra', $this->query_extra)) {
+       $exec .= " $option";
+     }
++    if ($option = drush_get_option('extra-dump')) {
++      $exec .= " $option";
++    }
+     return $exec;
+   }
+ 
+-- 
+2.20.1 (Apple Git-117)
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,12 @@
     basedir: "{{ composer_working_dir }}/vendor/drush/drush"
     strip: 1
 
+- name: Patch drush for extra-dump support
+  patch:
+    src: drush-extra-dump.patch
+    basedir: "{{ composer_working_dir }}/vendor/drush/drush"
+    strip: 1
+
 - name: Create symlink to the latest drush
   file:
     src: "{{ composer_working_dir }}/vendor/bin/drush"


### PR DESCRIPTION
Adds an option available in Drush 9.x for adding specific dump options, as GTID fails for the "SHOW TABLES" sql-dump uses to work out structures.

https://github.com/zeebox/webhop-orchestration/pull/320